### PR TITLE
KWP-69 most viewed posts list

### DIFF
--- a/library/functions/template-functions.php
+++ b/library/functions/template-functions.php
@@ -19,3 +19,26 @@ function displayBannerWaveLineSvg(): void {
     </div>';
 }
 
+function get_top_monthly_posts($limit = 5) {
+    $current_month = date('Y-m');
+
+    $args = [
+        'post_type' => 'post',
+        'posts_per_page' => $limit,
+        'ignore_sticky_posts' => 1,
+        'post__not_in'        => [ get_the_ID() ],
+        'meta_key' => 'monthly_views_count',
+        'orderby' => 'meta_value_num',
+        'order' => 'DESC',
+        'meta_query' => [
+            [
+                'key' => 'monthly_views_timestamp',
+                'value' => $current_month,
+                'compare' => '='
+            ]
+        ]
+    ];
+
+    return new \WP_Query( $args );
+}
+

--- a/library/hooks/hooks.php
+++ b/library/hooks/hooks.php
@@ -146,3 +146,26 @@ function render_dock_updater_js_admin_footer() {
 }
 
 add_action( 'admin_footer', __NAMESPACE__ . '\render_dock_updater_js_admin_footer' );
+
+function increment_monthly_post_views() {
+    if ( ! is_single() ) return; // only for single post pages
+
+    global $post;
+    if ( get_post_type( $post ) !== 'post' ) return;
+
+    $post_id = $post->ID;
+    $current_month = date('Y-m'); // e.g. 2025-08
+
+    $stored_month = get_post_meta( $post_id, 'monthly_views_timestamp', true );
+    $count = (int) get_post_meta( $post_id, 'monthly_views_count', true );
+
+    if ( $stored_month !== $current_month ) {
+        $count = 0;
+        update_post_meta( $post_id, 'monthly_views_timestamp', $current_month );
+    }
+
+    $count++;
+    update_post_meta( $post_id, 'monthly_views_count', $count );
+}
+
+add_action( 'wp', __NAMESPACE__ . '\increment_monthly_post_views' );

--- a/partials/sidebar/post-most-read-news.php
+++ b/partials/sidebar/post-most-read-news.php
@@ -1,17 +1,16 @@
+<?php
+
+use function \Opehuone\TemplateFunctions\get_top_monthly_posts;
+
+?>
 <div class="b-sidebar-news-lifts">
 	<h3 class="b-sidebar-news-lifts__title">
-		<?php esc_html_e( 'Luetuimmat uutiset (tähän joku logiikka, nyt antaa vain viimeisimmät', 'helsinki-universal' ); ?>
+		<?php esc_html_e( 'Kuukauden luetimmat uutiset', 'helsinki-universal' ); ?>
 	</h3>
 	<ul class="b-sidebar-news-lift__list">
 		<?php
-		$args = [
-			'post_type'           => 'post',
-			'posts_per_page'      => 5,
-			'ignore_sticky_posts' => 1,
-			'post__not_in'        => [ get_the_ID() ],
-		];
+		$query = get_top_monthly_posts();
 
-		$query = new WP_Query( $args );
 		if ( $query->have_posts() ) {
 			while ( $query->have_posts() ) {
 				$query->the_post();


### PR DESCRIPTION
Added a simple logic for most viewed posts for the given month.

Every time you click a post (**post_type="post"**), you increment the counter and update the date timestamp. If the month changes, the post's counter is zeroed. On the front-end side, we can fetch only the current month's posts by providing the current month as a meta_query. 

Here's an example:
<img width="496" height="842" alt="image" src="https://github.com/user-attachments/assets/e5914fb7-bdd1-4547-b3d6-5b32bf8e30c2" />
The image contains var_dump for testing purposes, you can see the view counter echoed on the screen (this var_dump is not in the pull request)