### PR TITLE
KWP-79-comment-notifications

### DIFF
--- a/library/acf-data/group_5ebd3020373be.json
+++ b/library/acf-data/group_5ebd3020373be.json
@@ -6,6 +6,7 @@
             "key": "field_5ebd303c4326a",
             "label": "Vastuuhenkilö 1",
             "name": "responsible_person_1",
+            "aria-label": "",
             "type": "email",
             "instructions": "Vastuuhenkilön email.",
             "required": 0,
@@ -24,6 +25,7 @@
             "key": "field_5ebd30664326b",
             "label": "Vastuuhenkilö 2",
             "name": "responsible_person_2",
+            "aria-label": "",
             "type": "email",
             "instructions": "Vastuuhenkilön email.",
             "required": 0,
@@ -42,9 +44,16 @@
     "location": [
         [
             {
+                "param": "post_type",
+                "operator": "==",
+                "value": "post"
+            }
+        ],
+        [
+            {
                 "param": "post_template",
                 "operator": "==",
-                "value": "custom-templates\/with-sidemenu.php"
+                "value": "default"
             }
         ]
     ],
@@ -54,7 +63,8 @@
     "label_placement": "top",
     "instruction_placement": "label",
     "hide_on_screen": "",
-    "active": 1,
+    "active": true,
     "description": "",
-    "modified": 1589457012
+    "show_in_rest": 0,
+    "modified": 1755500932
 }

--- a/library/hooks/comments.php
+++ b/library/hooks/comments.php
@@ -1,0 +1,46 @@
+<?php
+
+// Get seconds until midnight
+function seconds_until_midnight(): int {
+    return strtotime('tomorrow midnight') - time();
+}
+
+// Check if an e-mail was already notified today
+function has_already_been_notified_today( $email ): bool {
+    $key = 'notified_' . md5( strtolower( $email ) . '_' . date('Y-m-d') );
+    return ( false !== get_transient( $key ) );
+}
+
+// Mark email as notified today
+function mark_as_notified_today( $email ): void {
+    $key = 'notified_' . md5( strtolower( $email ) . '_' . date('Y-m-d') );
+    set_transient( $key, true, seconds_until_midnight() );
+}
+
+// Filter WP comment notification recipients
+add_filter('comment_notification_recipients', function( $emails, $comment_id ) {
+    $comment = get_comment( $comment_id );
+    if ( ! $comment ) {
+        return [];
+    }
+
+    $post_id = $comment->comment_post_ID;
+
+    // Get ACF emails
+    $email1 = get_field( 'responsible_person_1', $post_id );
+    $email2 = get_field( 'responsible_person_2', $post_id );
+
+    $recipients = array_filter( [ $email1, $email2 ] );
+
+    // Only send to emails not yet notified today
+    $recipients = array_filter( $recipients, function( $email ) {
+        return ! has_already_been_notified_today( $email );
+    });
+
+    // Mark these recipients as notified
+    foreach ( $recipients as $email ) {
+        mark_as_notified_today( $email );
+    }
+
+    return $recipients;
+}, 10, 2 );

--- a/partials/single.php
+++ b/partials/single.php
@@ -36,6 +36,12 @@
 				<?php the_post_thumbnail( 'large', [ 'class' => 'single-post__featured-image' ] ); ?>
 				<?php the_content(); ?>
 				<?php get_template_part( 'partials/sidebar/post-category-tags' );  ?>
+                <?php
+                // Load the comment template if comments are open
+                if ( comments_open() ) {
+                    helsinki_comment_form();
+                }
+                ?>
 			</section>
 			<aside>
 				<div class="single-post__sidebar-post">


### PR DESCRIPTION
- Added comment section to posts.
- Commenting a post notifies the responsible people if they are found in the posts ACF. E-mail frequency is set to one per day and the "timer" resets every day at midnight.
- Changed the responsible people ACF to only be shown in post type post.