### PR TITLE
KWP-103 search page

### DIFF
--- a/library/functions/template-functions.php
+++ b/library/functions/template-functions.php
@@ -95,3 +95,13 @@ function get_top_monthly_posts($limit = 5): \WP_Query {
 
     return new \WP_Query( $args );
 }
+
+function get_top_parent_page_title( $post_id = null ): ?string {
+    $post_id = $post_id ?: get_the_ID();
+    $ancestors = get_post_ancestors( $post_id );
+    $top_parent = $ancestors ? end( $ancestors ) : $post_id;
+
+    return $top_parent ? get_the_title( $top_parent ) : null;
+}
+
+

--- a/partials/page-with-sidemenu.php
+++ b/partials/page-with-sidemenu.php
@@ -1,3 +1,7 @@
+<?php
+use function \Opehuone\TemplateFunctions\get_top_parent_page_title;
+?>
+
 <article class="content" data-current-page-id="<?php echo get_the_ID(); ?>">
 	<div class="hds-container opehuone-page opehuone-content-container">
 		<?php get_template_part( 'partials/breadcrumbs' ); ?>
@@ -19,6 +23,12 @@
 				<?php get_template_part( 'partials/page-meta' );  ?>
 				<?php the_post_thumbnail( 'large', [ 'class' => 'featured-image' ] ); ?>
 				<?php the_content(); ?>
+                <?php
+                $top_parent_title = get_top_parent_page_title();
+                if ( $top_parent_title ) {
+                    echo '<span data-fdk-tags style="display: none;">opehuone-search-label/' . esc_html( $top_parent_title ) .'</span>';
+                }
+                ?>
 			</div>
 		</div>
 	</div>

--- a/partials/page-without-sidemenu.php
+++ b/partials/page-without-sidemenu.php
@@ -1,3 +1,7 @@
+<?php
+use function \Opehuone\TemplateFunctions\get_top_parent_page_title;
+?>
+
 <article class="content">
 	<div class="hds-container opehuone-page opehuone-content-container">
 		<?php get_template_part( 'partials/breadcrumbs' ); ?>
@@ -12,6 +16,12 @@
 				<?php get_template_part( 'partials/page-meta' );  ?>
 				<?php the_post_thumbnail( 'large', [ 'class' => 'featured-image' ] ); ?>
 				<?php the_content(); ?>
+                <?php
+                $top_parent_title = get_top_parent_page_title();
+                if ( $top_parent_title ) {
+                    echo '<span data-fdk-tags style="display: none;">opehuone-search-label/' . esc_html( $top_parent_title ) .'</span>';
+                }
+                ?>
 			</div>
 		</div>
 	</div>

--- a/partials/sidebar/training-cornerlabels.php
+++ b/partials/sidebar/training-cornerlabels.php
@@ -19,6 +19,11 @@ foreach ( $terms as $term ) {
 	<?php the_svg( 'icons/oppiaste' ); ?>
 	<div class="icon-detail__text-content">
 		<span class="icon-detail__title"><?php esc_html_e( 'Oppiaste', 'helsinki-universal' ); ?></span>
-		<span data-fdk-tags class="icon-detail__subtitle"><?php echo esc_html( implode( ', ', $terms_array ) ); ?></span>
+		<span class="icon-detail__subtitle"><?php echo esc_html( implode( ', ', $terms_array ) ); ?></span>
+        <?php
+        foreach( $terms_array as $term ) {
+            echo '<span data-fdk-tags style="display: none;">opehuone-search-label/' . esc_html( $term ) .'</span>';
+        }
+        ?>
 	</div>
 </div>

--- a/partials/single.php
+++ b/partials/single.php
@@ -28,7 +28,7 @@
 
 					if ( ! empty( $cornerlabels ) && ! is_wp_error( $cornerlabels ) ) {
 						foreach ( $cornerlabels as $term ) {
-							echo '<span data-fdk-tags class="single-post__date-row-cornerlabel">' . esc_html( $term->name ) . '</span>';
+							echo '<span data-fdk-tags="opehuone-search-label/'. esc_html( $term->name ) .'" class="single-post__date-row-cornerlabel">' . esc_html( $term->name ) . '</span>';
 						}
 					}
 					?>

--- a/resources/js/lib/findkit.js
+++ b/resources/js/lib/findkit.js
@@ -50,12 +50,15 @@ const findkitUI = new FindkitUI({
             `;
         },
         Hit(props) {
+            const tags = props.hit.tags.filter(tag => tag.startsWith('opehuone-search-label/'));
+
             return html`
                 <div>
+                    ${tags.length > 0 && html`<div className="findkit-result-tag">${tags.map(tag => html`<span>${tag}</span>`)}</div>`}
                     <h2 class="findkit-result-header">
                         <a class="findkit-result-link" href=${props.hit.url}>${props.hit.title}</a>
                     </h2>
-                    <${props.parts.Highlight} />
+                    <${props.parts.Highlight}/>
                 </div>
             `;
         },
@@ -207,6 +210,18 @@ const findkitUI = new FindkitUI({
             color: #000;
             background-color: transparent;
             text-decoration: none;
+        }
+        
+        .findkit-result-tag {
+            color: black;
+            display: inline-block;
+            background-color: #cce0ff;
+            font-size: 10px;
+            line-height: 24px;
+            border-radius: 24px;
+            padding: 0px 12px;
+            margin-bottom: 10px;
+            font-weight: 500;
         }
     `,
 })


### PR DESCRIPTION
https://helsinkisolutionoffice.atlassian.net/browse/KWP-103
- Changed the indexable data attributes so that they include `opehuone-search-label/` prefix. This makes it easier to handle FindkitUI logic, because now we can just filter out all the unnecessary tags and keep only the ones we want to display
- These tags have been tested as best as I could from my local machine. Findkit hasn't indexed these tags with the new prefix yet, so the real testing will happen in the stage environment
- Also note that colors are hard-coded (for now)

Here's an example of how the tag would look:
<img width="1428" height="561" alt="image" src="https://github.com/user-attachments/assets/b37913f0-0945-483a-9a6a-6750f677237e" />
