### PR TITLE
KWP-103 small bug fixes

### DIFF
--- a/partials/single.php
+++ b/partials/single.php
@@ -28,7 +28,8 @@
 
 					if ( ! empty( $cornerlabels ) && ! is_wp_error( $cornerlabels ) ) {
 						foreach ( $cornerlabels as $term ) {
-							echo '<span data-fdk-tags="opehuone-search-label/'. esc_html( $term->name ) .'" class="single-post__date-row-cornerlabel">' . esc_html( $term->name ) . '</span>';
+							echo '<span class="single-post__date-row-cornerlabel">' . esc_html( $term->name ) . '</span>';
+                            echo '<span data-fdk-tags style="display: none;">opehuone-search-label/' . esc_html( $term->name ) .'</span>';
 						}
 					}
 					?>

--- a/resources/js/lib/findkit.js
+++ b/resources/js/lib/findkit.js
@@ -50,11 +50,13 @@ const findkitUI = new FindkitUI({
             `;
         },
         Hit(props) {
-            const tags = props.hit.tags.filter(tag => tag.startsWith('opehuone-search-label/'));
+            const tags = props.hit.tags
+                .filter(tag => tag.startsWith('opehuone-search-label/'))
+                .map(tag => tag.replace('opehuone-search-label/', ''));
 
             return html`
                 <div>
-                    ${tags.length > 0 && html`<div className="findkit-result-tag">${tags.map(tag => html`<span>${tag}</span>`)}</div>`}
+                    ${tags.length > 0 && tags.map(tag => html`<div className="findkit-result-tag"><span>${tag}</span></div>`)}
                     <h2 class="findkit-result-header">
                         <a class="findkit-result-link" href=${props.hit.url}>${props.hit.title}</a>
                     </h2>
@@ -222,6 +224,7 @@ const findkitUI = new FindkitUI({
             padding: 0px 12px;
             margin-bottom: 10px;
             font-weight: 500;
+            margin-right: 12px;
         }
     `,
 })


### PR DESCRIPTION
- Removed the tag prefix before rendering it in the search results
- Restructured HTML for tags, now each tag has its own wrapper and a margin-right so that they are not all contained in the same element
- For posts, changed how the FindkitUI indexes the tags. Adding it `data-fdk-tags="opehuone-search-label/..."` did not work, so I moved the indexable tag to an invisible span