### PR TITLE
KWP-140 old opehuone menu button

### DIFF
--- a/library/utils/walkers.php
+++ b/library/utils/walkers.php
@@ -20,9 +20,17 @@ class Opehuone_Menu_Walker extends Walker_Nav_Menu {
 			$indent = str_repeat("\t", $depth);
 		}
 
-		$classes = array('menu__item', 'menu__depth-' . $depth);
+        // Keep only custom CSS classes from the menu editor
+        $custom_classes = array_filter((array) $item->classes, function ( $class ) {
+            return ! preg_match('/^(menu\-item|current\-|menu\-item\-type|menu\-item\-object)/', $class );
+        });
 
-		if (
+        $classes = $custom_classes;
+        $classes[] = 'menu__item';
+        $classes[] = 'menu__depth-' . $depth;
+
+
+        if (
 			$item->current == 1 ||
 			$item->current_item_ancestor == true ||
 			$this->is_current_page_child_of_menu_item($item)

--- a/resources/scss/components/_menu.scss
+++ b/resources/scss/components/_menu.scss
@@ -3,8 +3,32 @@
     #main-menu {
         border-bottom: 1px solid black;
         width: 100%;
+        padding-right: 146px;
+
+        .vanha-opehuone {
+            margin-left: auto;
+            a {
+                display: inline-flex;
+                align-items: center;
+                gap: 0.5rem;
+                padding: 0.5rem 1.85rem;
+                border: 2px solid #000000;
+                background: transparent;
+                color: #000;
+                font-weight: 500;
+                text-decoration: none;
+                font-size: 1rem;
+
+                svg {
+                    width: 12px;
+                    height: 12px;
+                    margin-top: 0;
+                }
+            }
+        }
     }
 }
+
 .menu .menu__item {
     position: unset;
 }


### PR DESCRIPTION
-  Previously we overwrote all css classes that came with the menu, now we want to include custom CSS classes to the menu html in case any are added
- CSS style changes for the main menu. We can add **vanha-opehuone** CSS class for the menu item (last one in the list) and style it to look like a button

You can test this by adding a link element to the end of the menu like so:
<img width="996" height="1086" alt="image" src="https://github.com/user-attachments/assets/02604bdc-9dc5-41c6-ac54-422108c25b8a" />


Here is the result after adding **vanha-opehuone** class to the last menu item:
<img width="1793" height="404" alt="image" src="https://github.com/user-attachments/assets/bc7ea2d5-d969-4d91-beef-8a583ce0cdc7" />


Jira ticket for reference: https://helsinkisolutionoffice.atlassian.net/browse/KWP-140