### PR TITLE
Add archive links and a color theme to post category labels etc.

### DIFF
--- a/library/hooks/hooks.php
+++ b/library/hooks/hooks.php
@@ -178,3 +178,9 @@ function increment_monthly_post_views() {
     update_post_meta( $post_id, 'monthly_views_count', $count );
 }
 add_action( 'wp', __NAMESPACE__ . '\increment_monthly_post_views' );
+
+// Remove post tags from posts
+function remove_tags_from_posts() {
+    unregister_taxonomy_for_object_type( 'post_tag', 'post' );
+}
+add_action( 'init', __NAMESPACE__ . '\remove_tags_from_posts' );

--- a/library/taxonomies/post-theme.php
+++ b/library/taxonomies/post-theme.php
@@ -16,8 +16,8 @@ function init_taxonomy() {
 		'singular_name'              => _x( 'Aihe', 'taxonomy singular name', 'helsinki-universal' ),
 		'search_items'               => __( 'Etsi aiheita', 'helsinki-universal' ),
 		'all_items'                  => __( 'Kaikki aiheet', 'helsinki-universal' ),
-		'parent_item'                => __( 'Aiheen yläsivu', 'helsinki-universal' ),
-		'parent_item_colon'          => __( 'Aiheen yläsivu:', 'helsinki-universal' ),
+		'parent_item'                => __( 'Aiheen ylätaso', 'helsinki-universal' ),
+		'parent_item_colon'          => __( 'Aiheen ylätaso:', 'helsinki-universal' ),
 		'edit_item'                  => __( 'Muokkaa aihetta', 'helsinki-universal' ),
 		'update_item'                => __( 'Päivitä aihetta', 'helsinki-universal' ),
 		'add_new_item'               => __( 'Lisää uusi aihe', 'helsinki-universal' ),
@@ -44,6 +44,12 @@ function init_taxonomy() {
 		'show_in_nav_menus'  => false,
 		'show_tagcloud'      => false,
 		'show_admin_column'  => true,
+		'capabilities' => array(
+            'manage_terms' => 'manage_options',
+            'edit_terms'   => 'manage_options',
+            'delete_terms' => 'manage_options',
+            'assign_terms' => 'edit_posts',
+        ),
 
 	);
 	register_taxonomy( 'post_theme', [ 'post' ], $args );

--- a/partials/post-category-tags.php
+++ b/partials/post-category-tags.php
@@ -15,16 +15,16 @@ $archive_url = get_post_type_archive_link( $post_type );
 <ul class="post-tags post-tags--is-lg">
 	<?php
 	foreach ( $terms as $category ) {
-		$color = ! empty( get_term_meta( $category->term_id, 'button_color_theme', true ) ) ? get_term_meta( $category->term_id, 'button_color_theme', true ) : 'suomenlinna';
-        // $filtered_url = add_query_arg(
-        //     'filter_posts_theme', // This has to be prefixed, because sending taxonomy name as query string redirects to 404
-        //     $category->term_id,
-        //     $archive_url
-        // );
+		$color = get_term_meta( $category->term_id, 'color_theme', true ) ?: 'suomenlinna';
+        $filtered_url = add_query_arg(
+            'filter_category', // This has to be prefixed, because sending taxonomy name as query string redirects to 404
+            $category->term_id,
+            $archive_url
+        );
 
         ?>
 		<li class="has-post-tag-color-<?php echo esc_attr( $color ); ?>">
-            <a class="post-tags__clickable" href="#">
+            <a class="post-tags__clickable" href="<?php echo esc_url( $filtered_url ); ?>">
                 <?php echo esc_html( $category->name ); ?>
             </a>
 		</li>

--- a/partials/single.php
+++ b/partials/single.php
@@ -30,7 +30,7 @@ use function \Opehuone\TemplateFunctions\get_favorite_article_button;
 				<?php get_template_part('partials/page-meta' ); ?>
 				<?php the_post_thumbnail( 'large', [ 'class' => 'single-post__featured-image' ] ); ?>
 				<?php the_content(); ?>
-				<?php get_template_part( 'partials/sidebar/post-category-tags' );  ?>
+				<?php get_template_part( 'partials/post-category-tags' );  ?>
                 <?php
                 // Load the comment template if comments are open
                 if ( comments_open() ) {


### PR DESCRIPTION
Lisätty uutiskategorioiden linkkaus yksittäiselle uutissivulle. Linkki johtaa uutisten arkistosivulle, jossa oikea suodatus valmiina. Suodatettu taksonomia pitäisi näkyä Ajax-kutsussa sekä URL-parametreissa. Ajaxille käytetään `update_post_archive_results` funktiota. Lisätty myös kategorioiden väriteemaus.

Lisäksi piilotettu tarpeeton "post_tag" taksonomia uutisilta (post) ja estetty muiden kuin admin-käyttäjien muokkaus "post_theme" taksonomiaan.

<img width="1422" height="603" alt="image" src="https://github.com/user-attachments/assets/307a6eb7-bfac-4745-a893-276a587804dd" />

<img width="1913" height="854" alt="image" src="https://github.com/user-attachments/assets/9d495a19-a4d0-4efd-a730-85cf4032e87c" />
