### PR TITLE
KWP-59 dock bugfixes

### DIFF
--- a/library/acf-data/group_68b699a99a3fd.json
+++ b/library/acf-data/group_68b699a99a3fd.json
@@ -34,7 +34,7 @@
                 "class": "",
                 "id": ""
             },
-            "return_format": "url",
+            "return_format": "array",
             "library": "all",
             "min_width": "",
             "min_height": "",
@@ -65,5 +65,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1757401216
+    "modified": 1757912893
 }

--- a/library/classes/Services-api.php
+++ b/library/classes/Services-api.php
@@ -96,15 +96,14 @@ class Services_api extends WP_REST_Controller {
      */
     public function prepare_item_for_response( $item, $request ) {
 
-
         return [
             'post_id'     => $item['post_id'],
             'id'          => $item['id'],
             'title'       => $item['title'],
             'url'         => $item['url'],
             'description' => $item['description'],
-            'icon_url'    => $item['icon'],
-            'icon_alt'    => '',
+            'icon_url'    => $item['icon']['url'],
+            'icon_alt'    => $item['icon']['alt'] ?: $item['title'], // Default to title if alt text not set
             'is_default'  => $item['is_default'],
         ];
     }

--- a/library/utils/utils.php
+++ b/library/utils/utils.php
@@ -152,7 +152,7 @@ function the_services_row( bool $is_active, \User_services $user_services ) {
                 $service_post_id     = $row->post_id;
                 $service_url         = $row->url;
                 $service_icon_url    = $row->icon_url;
-                $service_icon_alt    = '';
+                $service_icon_alt    = $row->icon_alt;
                 $service_description = $row->description;
 
                 $args = [

--- a/partials/blocks/b-service-item.php
+++ b/partials/blocks/b-service-item.php
@@ -25,10 +25,12 @@ $hover_args = [
                 <span class="services-column__first-letter">
 					<?php echo esc_html( substr( $args['title'], 0, 1 ) ); ?>
 				</span>
+                <span class="services-column__tooltip"><?php echo esc_html( $args['title'] ); ?></span>
             <?php else : ?>
                 <img src="<?php echo esc_url( $args['icon_url'] ); ?>"
                      alt="<?php echo esc_attr( $args['icon_alt'] ); ?>"
                      class="services-column__image"/>
+                <span class="services-column__tooltip"><?php echo esc_html( $args['title'] ); ?></span>
             <?php endif; ?>
         </a>
         <?php if ( is_user_logged_in() ) : ?>

--- a/resources/js/lib/ownServices.js
+++ b/resources/js/lib/ownServices.js
@@ -55,6 +55,7 @@ const addNewOwnService = () => {
                 notifications.addClass('success');
                 inactiveRow.html(content);
                 clearInputs();
+                updateInactiveTogglersVisibility();
 
                 setTimeout(() => {
                     notifications.fadeOut();
@@ -117,8 +118,9 @@ const pinOwnService = () => {
             }),
             success: function (content) {
                 setServicesRow(parseInt(setVisible), content);
-                closestColumn.fadeOut();
-                updateInactiveTogglersVisibility();
+                closestColumn.fadeOut('fast', function() {
+                    updateInactiveTogglersVisibility();
+                });
             }
         });
     });

--- a/resources/js/lib/services.js
+++ b/resources/js/lib/services.js
@@ -158,16 +158,39 @@ export function updateInactiveTogglersVisibility() {
 	const $inactiveTogglers = jQuery('.services-row--inactive .services-column__toggler');
 
 	if (activeCount >= 10) {
-		// hide/disable add buttons in inactive section
-		$inactiveTogglers
-			.prop('disabled', true)
-			.attr('aria-hidden', 'true')
-			.css('display', 'none');
+		$inactiveTogglers.each(function () {
+			const $toggler = jQuery(this);
+			const $ul = $toggler.next('ul'); // <-- get sibling UL
+			const $listItems = $ul.find('li');
+
+			if ($listItems.length === 1) {
+				// hide/disable the whole toggler
+				$toggler
+					.prop('disabled', true)
+					.attr('aria-hidden', 'true')
+					.css('display', 'none');
+			} else {
+				// hide only the "pin-own" item
+				$ul.find('.services-item-dropdown__link--pin-own')
+					.closest('li')
+					.hide();
+			}
+		});
 	} else {
-		// show/enable them again
-		$inactiveTogglers
-			.prop('disabled', false)
-			.removeAttr('aria-hidden')
-			.css('display', '');
+		// re-enable everything
+		$inactiveTogglers.each(function () {
+			const $toggler = jQuery(this);
+			const $ul = $toggler.next('ul'); // <-- get sibling UL
+			const $listItems = $ul.find('li');
+
+			// show/enable the toggler again
+			$toggler
+				.prop('disabled', false)
+				.removeAttr('aria-hidden')
+				.css('display', '');
+
+			// make sure all list items are visible again
+			$listItems.show();
+		});
 	}
 }

--- a/resources/scss/components/_services.scss
+++ b/resources/scss/components/_services.scss
@@ -107,11 +107,28 @@
   }
 
   &__image {
-    width: 50%;
-    height: 50%;
+    width: 85%;
+    height: 85%;
     object-fit: contain;
     display: block;
     transition: transform 0.2s ease-in-out;
+  }
+
+  &__tooltip {
+    position: absolute;
+    top: 115%;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #4D4D4D;
+    color: #fff;
+    padding: 5px 10px;
+    border-radius: 4px;
+    font-size: 14px;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease-in-out;
+    z-index: 10;
   }
 
   &__toggler {
@@ -190,6 +207,9 @@
     &:hover {
       .services-column__hover-content {
         display: none; // dont want to show this at the moment
+      }
+      .services-column__tooltip {
+        opacity: 1;
       }
     }
   }


### PR DESCRIPTION
General changes:
- Changed services image field to return as an array instead of a link, so that we can easily handle image alt-attribute in the code

CSS changes:
- Increase the size of the image by 35%
- Added a tooltip, which is displayed on hover
<img width="1023" height="376" alt="image" src="https://github.com/user-attachments/assets/b544f9f5-b496-4369-b18c-d00d848231db" />



JS changes:
- For own service added links, always display the "Poista" option, but hide the pin option if the top bar has 10 services. Hide the dropdown icon for regular services, since they don't have "Poista" option.

<img width="1052" height="381" alt="image" src="https://github.com/user-attachments/assets/55f8f10c-34d0-4aa2-87dd-e63308634665" />