### PR TITLE
KWP-182 changed commenting URL to use SSO

### DIFF
--- a/library/hooks/hooks.php
+++ b/library/hooks/hooks.php
@@ -195,3 +195,15 @@ function remove_tags_from_posts() {
     unregister_taxonomy_for_object_type( 'post_tag', 'post' );
 }
 add_action( 'init', __NAMESPACE__ . '\remove_tags_from_posts' );
+
+add_filter( 'comment_form_defaults', function( $defaults ) {
+    $defaults['must_log_in'] = 'Sinun täytyy <a href="javascript:void(0)" onclick="window.wpo365.pintraRedirect.toMsOnline()">kirjautua sisään</a> kommentoidaksesi.';
+    return $defaults;
+});
+
+add_filter( 'comment_reply_link', function( $link ) {
+    if ( ! is_user_logged_in() ) {
+        $link = '<a href="javascript:void(0)" onclick="window.wpo365.pintraRedirect.toMsOnline()">Kirjaudu sisään vastataksesi</a>';
+    }
+    return $link;
+}, 10, 4 );


### PR DESCRIPTION
Change the commenting links to SSO links.

Might be possible that we need to include the "wpo365OpenIdRedirect" ID to the wrapper element, however it is possible that wso365 knows to use the ID found from the header. This needs to be tested in staging environment.