### PR TITLE
Feature/kwp 174 front page filters fix

### DIFF
--- a/library/hooks/ajax-helpers.php
+++ b/library/hooks/ajax-helpers.php
@@ -2,6 +2,7 @@
 
 namespace Opehuone\AjaxHelpers;
 
+use function Opehuone\TemplateFunctions\display_sticky_and_regular_posts;
 use function Opehuone\Utils\the_own_services_row;
 use function Opehuone\Utils\the_services_row;
 
@@ -570,114 +571,79 @@ function ajax_pin_own_service() {
 add_action( 'wp_ajax_pin_own_service', __NAMESPACE__ . '\\ajax_pin_own_service' );
 
 function ajax_update_front_page_posts() {
-	// Get cornerLabels from POST request
-	$cornerlabel_ids = isset( $_POST['cornerLabels'] ) ? $_POST['cornerLabels'] : '';
+    $cornerlabel_ids = $_POST['cornerLabels'] ?? [];
 
-	if ( $cornerlabel_ids === '' ) {
-		$cornerlabel_ids = [];
-	}
+    if ( ! is_array( $cornerlabel_ids ) ) {
+        $cornerlabel_ids = explode( ',', $cornerlabel_ids );
+    }
 
-	$user_id = intval( $_POST['userId'] );
+    $user_id = intval( $_POST['userId'] );
 
-	$current_favs = get_user_meta( $user_id, 'opehuone_favs', true );
-	if ( ! $current_favs ) {
-		$current_favs = [];
-	}
+    $current_favs = get_user_meta( $user_id, 'opehuone_favs', true );
+    if ( ! $current_favs ) {
+        $current_favs = [];
+    }
 
-	if ( ! is_array( $cornerlabel_ids ) ) {
-		$cornerlabel_ids = explode( ',', $cornerlabel_ids );
-	}
+    $max_posts = 8;
 
-	// Fetch sticky posts first
-	$sticky_posts = get_option( 'sticky_posts' );
-	$sticky_posts = ! empty( $sticky_posts ) ? array_map( 'intval', $sticky_posts ) : [];
+    // Base query arguments
+    $query_args = [
+        'post_type' => 'post',
+    ];
 
-	$query_args = [
-		'post_type'           => 'post',
-		'posts_per_page'      => 8,
-		'ignore_sticky_posts' => true, // Prevent default WP behavior
-	];
+    // Tax filter
+    if ( ! empty( $cornerlabel_ids ) ) {
+        $query_args['tax_query'] = [
+            [
+                'taxonomy' => 'cornerlabels',
+                'field'    => 'term_id',
+                'terms'    => $cornerlabel_ids,
+            ],
+        ];
+    }
 
-	// If there are selected filters, add them to query
-	if ( ! empty( $cornerlabel_ids ) ) {
-		$query_args['tax_query'] = [
-			[
-				'taxonomy' => 'cornerlabels',
-				'field'    => 'term_id',
-				'terms'    => $cornerlabel_ids,
-			],
-		];
-	}
+    // --- Sticky posts ---
+    $sticky_posts = get_option( 'sticky_posts' );
+    $sticky_posts = ! empty( $sticky_posts ) ? array_map( 'intval', $sticky_posts ) : [];
 
-	// Fetch sticky posts first if they match the filters
-	$sticky_query_args = wp_parse_args( [
-		'post__in' => $sticky_posts,
-		'orderby'  => 'post__in', // Keep sticky posts first
-	], $query_args );
+    $sticky_query_args = wp_parse_args( [
+        'post__in'       => $sticky_posts,
+        'posts_per_page' => $max_posts, // important: cap stickies to max_posts
+        'orderby'        => 'post__in',
+    ], $query_args );
 
-	$sticky_query = new \WP_Query( $sticky_query_args );
+    $sticky_query = new \WP_Query( $sticky_query_args );
+    $sticky_count = count( $sticky_query->posts );
 
-	// Fetch regular posts, excluding sticky ones
-	$regular_query_args = wp_parse_args( [
-		'post__not_in' => $sticky_posts, // Prevent duplicates
-	], $query_args );
+    // --- Regular posts ---
+    $remaining = max( 0, $max_posts - $sticky_count );
 
-	$regular_query = new \WP_Query( $regular_query_args );
+    $regular_query_args = wp_parse_args( [
+        'post__not_in'   => $sticky_posts,
+        'posts_per_page' => $remaining, // only fetch remaining
+    ], $query_args );
 
-	ob_start();
+    $regular_query = new \WP_Query( $regular_query_args );
 
-	// Output sticky posts first
-	if ( $sticky_query->have_posts() ) {
-		while ( $sticky_query->have_posts() ) {
-			$sticky_query->the_post();
+    // --- Output ---
+    ob_start();
 
-			$block_args = [
-				'post_id'    => get_the_ID(),
-				'title'      => get_the_title(),
-				'url'        => get_the_permalink(),
-				'media_id'   => get_post_thumbnail_id(),
-				'excerpt'    => get_the_excerpt(),
-				'is_sticky'  => true, // Force as sticky
-				'categories' => get_the_category(),
-				'date'       => get_the_date(),
-				'is_pinned'  => in_array( get_the_ID(), $current_favs ),
-			];
+    display_sticky_and_regular_posts( $sticky_count, $sticky_query, $current_favs, $remaining, $regular_query );
 
-			get_template_part( 'partials/template-blocks/b-post', null, $block_args );
-		}
-	}
+    if ( $sticky_count + count( $regular_query->posts ) === 0 ) {
+        return;
+    }
 
-	// Output regular posts after sticky ones
-	if ( $regular_query->have_posts() ) {
-		while ( $regular_query->have_posts() ) {
-			$regular_query->the_post();
+    $output = ob_get_clean();
 
-			$block_args = [
-				'post_id'    => get_the_ID(),
-				'title'      => get_the_title(),
-				'url'        => get_the_permalink(),
-				'media_id'   => get_post_thumbnail_id(),
-				'excerpt'    => get_the_excerpt(),
-				'is_sticky'  => false, // Regular post
-				'categories' => get_the_category(),
-				'date'       => get_the_date(),
-				'is_pinned'  => in_array( get_the_ID(), $current_favs ),
-			];
+    wp_reset_postdata();
 
-			get_template_part( 'partials/template-blocks/b-post', null, $block_args );
-		}
-	} else {
-		echo '<p>Ei uutisia.</p>';
-	}
-
-	$output = ob_get_clean();
-	wp_reset_postdata();
-
-	wp_send_json_success( [
-		'message' => 'Uutiset päivitetty',
-		'output'  => $output
-	] );
+    wp_send_json_success( [
+        'message'        => 'Uutiset päivitetty',
+        'output'         => $output,
+    ] );
 }
+
 
 add_action( 'wp_ajax_update_front_page_posts', __NAMESPACE__ . '\\ajax_update_front_page_posts' );
 add_action( 'wp_ajax_nopriv_update_front_page_posts', __NAMESPACE__ . '\\ajax_update_front_page_posts' );

--- a/partials/front-page-filters.php
+++ b/partials/front-page-filters.php
@@ -1,6 +1,9 @@
 <?php
+use function \Opehuone\TemplateFunctions\get_user_cornerlabels_with_added_default_value;
+
 $what_to_target = isset( $args['to_target'] ) ? $args['to_target'] : 'posts';
-$cornerlabels   = Opehuone_user_settings_reader::get_user_settings_key( 'cornerlabels' );
+$cornerlabels   = get_user_cornerlabels_with_added_default_value();
+
 ?>
 <div class="front-page-posts-filter">
 	<form class="front-page-posts-filter__posts-form" data-target="<?php echo esc_attr( $what_to_target ); ?>"

--- a/partials/front-page-news.php
+++ b/partials/front-page-news.php
@@ -1,61 +1,80 @@
 <?php
-$cornerlabels = Opehuone_user_settings_reader::get_user_settings_key( 'cornerlabels' );
+use function \Opehuone\TemplateFunctions\display_sticky_and_regular_posts;
+use function \Opehuone\TemplateFunctions\get_user_cornerlabels_with_added_default_value;
 
-$query_args = [
-	'post_type'      => 'post',
-	'posts_per_page' => 8,
+$cornerlabels = get_user_cornerlabels_with_added_default_value();
+
+$user_favs = \Opehuone\Utils\get_user_favs();
+$max_posts = 8;
+
+// Sticky posts
+$sticky_posts = get_option( 'sticky_posts' );
+$sticky_posts = ! empty( $sticky_posts ) ? array_map('intval', $sticky_posts ) : [];
+
+$sticky_query_args = [
+    'post_type'      => 'post',
+    'posts_per_page' => $max_posts,
+    'post__in'       => $sticky_posts,
+    'orderby'        => 'post__in',
 ];
 
-if ( is_array( $cornerlabels ) && count( $cornerlabels ) > 0 ) {
-	$tax_query  = [
-		'tax_query' => [
-			[
-				'taxonomy' => 'cornerlabels',
-				'field'    => 'id',
-				'terms'    => $cornerlabels,
-			],
-		]
-	];
-	$query_args = wp_parse_args( $tax_query, $query_args );
+if ( ! empty( $cornerlabels ) ) {
+    $sticky_query_args['tax_query'] = [
+        [
+            'taxonomy' => 'cornerlabels',
+            'field'    => 'term_id',
+            'terms'    => $cornerlabels,
+        ],
+    ];
 }
 
-$query = new WP_Query( $query_args );
+$sticky_query = new WP_Query( $sticky_query_args );
+$sticky_count = count( $sticky_query->posts );
 
-if ( ! $query->have_posts() ) {
-	return;
+// Regular (non-sticky) posts to fill remaining slots
+$remaining = max(0, $max_posts - $sticky_count);
+
+$regular_query_args = [
+    'post_type'      => 'post',
+    'posts_per_page' => $remaining,
+    'post__not_in'   => $sticky_posts,
+];
+
+if ( ! empty( $cornerlabels ) ) {
+    $regular_query_args['tax_query'] = [
+        [
+            'taxonomy' => 'cornerlabels',
+            'field'    => 'term_id',
+            'terms'    => $cornerlabels,
+        ],
+    ];
 }
-$user_favs = \Opehuone\Utils\get_user_favs();
+
+$regular_query = new WP_Query( $regular_query_args );
+
+// Return if nothing is found
+if ( $sticky_count + count( $regular_query->posts ) === 0 ) {
+    return;
+}
+
 ?>
+
 <h2 class="front-page-posts-filter__title">
-	<?php esc_html_e( 'Uutiset', 'helsini-universal' ); ?>
+    <?php esc_html_e('Uutiset', 'helsinki-universal'); ?>
 </h2>
-<?php get_template_part( 'partials/front-page-filters' ); ?>
+
+<?php get_template_part('partials/front-page-filters'); ?>
+
 <div class="b-posts-row">
-	<?php
-	while ( $query->have_posts() ) {
-		$query->the_post();
+    <?php
+    display_sticky_and_regular_posts($sticky_count, $sticky_query, $user_favs, $remaining, $regular_query);
 
-		$block_args = [
-			'post_id'    => get_the_ID(),
-			'title'      => get_the_title(),
-			'url'        => get_the_permalink(),
-			'media_id'   => get_post_thumbnail_id(),
-			'excerpt'    => get_the_excerpt(),
-			'is_sticky'  => is_sticky(),
-			'categories' => get_the_category(),
-			'date'       => get_the_date(),
-			'is_pinned'  => in_array( get_the_ID(), $user_favs ),
-		];
-
-		get_template_part( 'partials/template-blocks/b-post', '', $block_args );
-	}
-
-	wp_reset_postdata();
-	?>
+    wp_reset_postdata();
+    ?>
 </div>
+
 <div class="b-posts-row__button-wrapper">
-	<a href="<?php echo esc_url( get_post_type_archive_link( 'post' ) ); ?>" class="b-posts-row__more-btn">
-		<?php esc_html_e( 'Katso kaikki uutiset', 'helsinki-universal' ); ?>
-	</a>
+    <a href="<?php echo esc_url(get_post_type_archive_link('post')); ?>" class="b-posts-row__more-btn">
+        <?php esc_html_e('Katso kaikki uutiset', 'helsinki-universal'); ?>
+    </a>
 </div>
-

--- a/partials/front-page-training.php
+++ b/partials/front-page-training.php
@@ -1,5 +1,7 @@
 <?php
-$cornerlabels = Opehuone_user_settings_reader::get_user_settings_key( 'cornerlabels' );
+use function \Opehuone\TemplateFunctions\get_user_cornerlabels_with_added_default_value;
+
+$cornerlabels   = get_user_cornerlabels_with_added_default_value();
 
 $query_args = [
 	'post_type'      => 'training',

--- a/resources/js/lib/postsFiltering.js
+++ b/resources/js/lib/postsFiltering.js
@@ -128,7 +128,16 @@ export const postsFiltering = () => {
 	);
 };
 
+// Handle cornerlabels in the URL for the Pedagogiikka page
 document.addEventListener('DOMContentLoaded', () => {
+	const isPedagogiikkaPage = document.querySelector(
+		'#front-page-filter-pages'
+	);
+
+	if (!isPedagogiikkaPage) {
+		return;
+	}
+
 	const checkboxes = document.querySelectorAll(
 		'input[name="cornerlabels[]"]'
 	);

--- a/resources/js/lib/postsFiltering.js
+++ b/resources/js/lib/postsFiltering.js
@@ -114,14 +114,17 @@ const handleCheckboxChange = (form, target) => {
 };
 
 export const postsFiltering = () => {
+	// Front page
 	detectCheckboxChange(
 		document.querySelector('#front-page-filter-posts'),
-		true
+		false
 	);
+	// Koulutukset page
 	detectCheckboxChange(
 		document.querySelector('#front-page-filter-training'),
 		false
 	);
+	// Pedagogiikka page
 	detectCheckboxChange(
 		document.querySelector('#front-page-filter-pages'),
 		true


### PR DESCRIPTION
- Include "Kaikille yhteinen" default cornerlabels value as pre-selected checkbox for both news and trainings on the front page
- AJAX and template WP_Query fixes, previously the logic was inconsistent. Now the maximum amount of posts shown on the front page for the news section is limited to eight. Ex. if two posts are pinned, only six will be fetched for the remaining posts
- Refactored the code and created some reusable functions
- Fixed a JS bug where the cornerlabels were added to the URL on the front page, even though it should only be limited to Pedagogiikka pages