### PR TITLE
fix/KWP-263-daterow-and-ingress-changes

### DIFF
--- a/partials/page-with-sidemenu.php
+++ b/partials/page-with-sidemenu.php
@@ -14,12 +14,12 @@ use function \Opehuone\TemplateFunctions\get_top_parent_page_title;
 			</aside>
 			<div>
 				<h1 class="page-title"><?php the_title(); ?></h1>
+				<?php get_template_part( 'partials/page-meta' );  ?>
 				<?php if ( has_excerpt() ) : ?>
 					<p class="single-post__excerpt">
 						<?php echo get_the_excerpt(); ?>
 					</p>
 				<?php endif; ?>
-				<?php get_template_part( 'partials/page-meta' );  ?>
 				<?php the_post_thumbnail( 'large', [ 'class' => 'featured-image' ] ); ?>
 				<?php the_content(); ?>
                 <?php

--- a/partials/page-without-sidemenu.php
+++ b/partials/page-without-sidemenu.php
@@ -8,12 +8,12 @@ use function \Opehuone\TemplateFunctions\get_top_parent_page_title;
 		<div class="opehuone-grid">
 			<div>
 				<h1 class="page-title"><?php the_title(); ?></h1>
+				<?php get_template_part( 'partials/page-meta' );  ?>
 				<?php if ( has_excerpt() ) : ?>
 					<p class="single-post__excerpt">
 						<?php echo get_the_excerpt(); ?>
 					</p>
 				<?php endif; ?>
-				<?php get_template_part( 'partials/page-meta' );  ?>
 				<?php the_post_thumbnail( 'large', [ 'class' => 'featured-image' ] ); ?>
 				<?php the_content(); ?>
                 <?php

--- a/partials/single.php
+++ b/partials/single.php
@@ -22,12 +22,12 @@ use function \Opehuone\TemplateFunctions\get_favorite_article_button;
                     echo '</div>';
                 }
                 ?>
+				<?php get_template_part('partials/page-meta' ); ?>
 				<?php if ( has_excerpt() ) : ?>
 					<p class="single-post__excerpt">
 						<?php echo get_the_excerpt(); ?>
 					</p>
 				<?php endif; ?>
-				<?php get_template_part('partials/page-meta' ); ?>
 				<?php the_post_thumbnail( 'large', [ 'class' => 'single-post__featured-image' ] ); ?>
 				<?php the_content(); ?>
 				<?php get_template_part( 'partials/post-category-tags' );  ?>


### PR DESCRIPTION
Changed meta element above ingress/excerpt for single post & page templates:

<img width="699" height="694" alt="image" src="https://github.com/user-attachments/assets/170b2c6c-ef77-4c11-ace2-c838f1bc3d3e" />


https://helsinkisolutionoffice.atlassian.net/browse/KWP-263