### PR TITLE
fix/KWP-274-sticky-posts-order

### DIFF
--- a/library/hooks/ajax-helpers.php
+++ b/library/hooks/ajax-helpers.php
@@ -616,7 +616,8 @@ function ajax_update_front_page_posts() {
         $sticky_query_args = wp_parse_args( [
             'post__in'       => $sticky_posts,
             'posts_per_page' => $max_posts, // important: cap stickies to max_posts
-            'orderby'        => 'post__in',
+            'orderby'        => 'date', // order by date to show the most recent sticky posts first
+			'order'          => 'DESC',
         ], $query_args );
 
         $sticky_query = new \WP_Query( $sticky_query_args );

--- a/partials/front-page-news.php
+++ b/partials/front-page-news.php
@@ -28,8 +28,9 @@ if ( ! empty( $sticky_posts ) ) {
     $sticky_query_args = [
             'post_type'      => 'post',
             'posts_per_page' => $max_posts,
-            'post__in'      => $sticky_posts,
-            'orderby' => 'post__in'
+            'post__in'       => $sticky_posts,
+            'orderby'        => 'date', // order by date to show the most recent sticky posts first
+			'order'          => 'DESC',
     ];
 
     $sticky_query_args['tax_query'] = $tax_query;


### PR DESCRIPTION
Changed sticky posts args so orderby is now date (latest published articles comes always first)

<img width="728" height="560" alt="image" src="https://github.com/user-attachments/assets/b22a11f7-7225-4970-989b-00b034b656d9" />

https://helsinkisolutionoffice.atlassian.net/browse/KWP-274