### PR TITLE
feature/KWP-269-taxonomy-capabilities

### DIFF
--- a/library/taxonomies/cornerlabels.php
+++ b/library/taxonomies/cornerlabels.php
@@ -44,6 +44,12 @@ function init_taxonomy() {
 		'show_in_nav_menus'  => true,
 		'show_tagcloud'      => false,
 		'show_in_rest'       => true,
+		'capabilities'       => [
+            'manage_terms' => 'manage_options',
+            'edit_terms'   => 'manage_options',
+            'delete_terms' => 'manage_options',
+            'assign_terms' => 'edit_posts',
+        ],
 	);
 	register_taxonomy( 'cornerlabels', [ 'post', 'training', 'page', 'links', 'services' ], $args );
 

--- a/library/taxonomies/post-categories.php
+++ b/library/taxonomies/post-categories.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Filter to change capabilities for the default category taxonomy
+ * Only admins can manage categories, but editors and authors can just assign them to posts.
+ */
+add_filter('register_taxonomy_args', function ( $args, $taxonomy ) {
+
+    if ( $taxonomy === 'category' ) {
+        $args['capabilities'] = [
+            'manage_terms' => 'manage_options',
+            'edit_terms'   => 'manage_options',
+            'delete_terms' => 'manage_options',
+            'assign_terms' => 'edit_posts',
+        ];
+    }
+
+    return $args;
+
+}, 10, 2);

--- a/library/taxonomies/post-theme.php
+++ b/library/taxonomies/post-theme.php
@@ -43,7 +43,6 @@ function init_taxonomy() {
 		'show_in_rest'       => true,
 		'show_in_nav_menus'  => false,
 		'show_tagcloud'      => false,
-		'show_admin_column'  => true,
 		'capabilities' => array(
             'manage_terms' => 'manage_options',
             'edit_terms'   => 'manage_options',

--- a/library/taxonomies/training-theme.php
+++ b/library/taxonomies/training-theme.php
@@ -44,6 +44,12 @@ function init_taxonomy() {
 		'show_in_rest'       => true,
 		'show_in_nav_menus'  => true,
 		'show_tagcloud'      => false,
+		'capabilities'       => [
+            'manage_terms' => 'manage_options',
+            'edit_terms'   => 'manage_options',
+            'delete_terms' => 'manage_options',
+            'assign_terms' => 'edit_posts',
+        ],
 	);
 	register_taxonomy( 'training_theme', [ 'training' ], $args );
 


### PR DESCRIPTION
Added capabilities to taxonomies so only admins can manage (add, edit, delete) and other users can just assign

<img width="748" height="258" alt="image" src="https://github.com/user-attachments/assets/38dc1b9a-d1e9-472e-8c2b-6a99bdea5181" />

https://helsinkisolutionoffice.atlassian.net/browse/KWP-269