### PR TITLE
feature/KWP-261-pages-and-posts-published-and-edited-date

### DIFF
--- a/partials/page-meta.php
+++ b/partials/page-meta.php
@@ -5,15 +5,15 @@ use function \Opehuone\TemplateFunctions\get_favorite_article_button;
 <div class="single-post__date-row">
     <span>
         <?php
-        echo get_the_date();
-        $published = get_the_date( 'U' ); // Unix timestamp of publish date
-        $modified  = get_the_modified_date( 'U' ); // Unix timestamp of modified date
-
-        // Display modified date string if it differs from the published date
-        if ( $modified !== $published ) {
-            echo '<span class="single-post__date-row-modified-date">Päivitetty ' . get_the_modified_date() . '</span>';
+        // Check if post type is post (show only published date)
+        if ( 'post' === get_post_type() ) {
+            echo get_the_date();
         }
 
+        // Check if post type is page (show always modified date with prefix text "Päivitetty")
+        if ( 'page' === get_post_type() ) {
+            echo 'Päivitetty ' . get_the_modified_date();
+        }
         ?>
     </span>
     <?php


### PR DESCRIPTION
Changes for date info --> posts shows only published date and pages only modified date

<img width="761" height="460" alt="image" src="https://github.com/user-attachments/assets/5e333a98-41ab-407d-bb37-452bc9cbb200" />

https://helsinkisolutionoffice.atlassian.net/browse/KWP-261